### PR TITLE
Replace deprecated `or` with `||`

### DIFF
--- a/src/constraints.ml
+++ b/src/constraints.ml
@@ -74,7 +74,7 @@ let fold_region f g acc = Region.fold_edges f g.region_graph acc
 let fold_dirt f g acc = Dirt.fold_edges f g.dirt_graph acc
 
 let add_ty_constraint ty1 ty2 cstr =
-  let within, without = List.partition (fun g -> Ty.mem ty1 g or Ty.mem ty2 g) cstr.ty_graph in
+  let within, without = List.partition (fun g -> Ty.mem ty1 g || Ty.mem ty2 g) cstr.ty_graph in
   let new_graphs =
     match within with
     | [] -> (Ty.add_edge ty1 ty2 Ty.empty) :: without

--- a/src/tctx.ml
+++ b/src/tctx.ml
@@ -318,8 +318,8 @@ let extend_with_variances ~pos tydefs =
           begin match Common.lookup p ps with
           | None -> assert false
           | Some (posvar, negvar) ->
-              posvar := !posvar or posi;
-              negvar := !negvar or nega
+              posvar := !posvar || posi;
+              negvar := !negvar || nega
           end
       | T.Apply (t, (tys, drts, rgns)) ->
           begin match Common.lookup t !tctx with
@@ -395,15 +395,15 @@ let extend_with_variances ~pos tydefs =
       begin match Common.lookup d ds with
       | None -> assert false
       | Some (posvar, negvar) ->
-          posvar := !posvar or posi;
-          negvar := !negvar or nega
+          posvar := !posvar || posi;
+          negvar := !negvar || nega
       end
     and region_param posi nega r =
       begin match Common.lookup r rs with
       | None -> assert false
       | Some (posvar, negvar) ->
-          posvar := !posvar or posi;
-          negvar := !negvar or nega
+          posvar := !posvar || posi;
+          negvar := !negvar || nega
       end
     in match def with
       | Record tys -> List.iter (fun (_, t) -> ty true false t) tys


### PR DESCRIPTION
Ocaml 4.01.0 whines about `or` and wants it replaced with `||`.
