### PR TITLE
Add an OPAM file for eff.

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+name: "eff"
+version: "dev"
+maintainer: "matija@pretnar.info"
+authors: ["Andrej Bauer <Andrej.Bauer@andrej.com>"
+          "Matija Pretnar <matija@pretnar.info>"]
+homepage: "http://www.eff-lang.org/"
+bug-reports: "https://github.com/matijapretnar/eff/issues"
+license: "BSD2"
+dev-repo: "git@github.com:matijapretnar/eff.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlfind"
+  "menhir" 
+]


### PR DESCRIPTION
This should makes the installation instructions a little simpler.  Once you have OPAM installed you can switch to a suitable OCaml compiler (`opam switch 4.02.1`) and then run

```
opam pin add eff git@github.com:matijapretnar/eff.git
```

to download the dependencies and build and install eff.