### PR TITLE
Improve location annotation notation by opening CoreUtils.

### DIFF
--- a/src/main/shell.ml
+++ b/src/main/shell.ml
@@ -5,6 +5,8 @@ let help_text =
   ^ "#help;;            print this help\n" ^ "#quit;;            exit eff\n"
   ^ "#use \"<file>\";;  load commands from file\n"
 
+open CoreUtils
+
 module TypeSystem = SimpleInfer
 module Runtime = Eval
 
@@ -22,7 +24,7 @@ let _ = Random.self_init ()
 
 (* [exec_cmd ppf st cmd] executes toplevel command [cmd] in a state [st].
    It prints the result to [ppf] and returns the new state. *)
-let rec exec_cmd ppf st {CoreUtils.it= cmd; CoreUtils.at= loc} =
+let rec exec_cmd ppf st {it= cmd; at= loc} =
   match cmd with
   | Commands.Term t ->
       let c = Desugarer.desugar_computation st.desugarer_state t in
@@ -120,7 +122,7 @@ let rec exec_cmd ppf st {CoreUtils.it= cmd; CoreUtils.at= loc} =
       Tctx.extend_tydefs ~loc tydefs' ;
       {st with desugarer_state= desugarer_state'}
 
-and exec_cmds ppf state cmds = CoreUtils.fold (exec_cmd ppf) state cmds
+and exec_cmds ppf state cmds = fold (exec_cmd ppf) state cmds
 
 (* Parser wrapper *)
 and parse lexbuf =

--- a/src/main/shell.ml
+++ b/src/main/shell.ml
@@ -6,7 +6,6 @@ let help_text =
   ^ "#use \"<file>\";;  load commands from file\n"
 
 open CoreUtils
-
 module TypeSystem = SimpleInfer
 module Runtime = Eval
 

--- a/src/parsing/desugarer.ml
+++ b/src/parsing/desugarer.ml
@@ -1,7 +1,6 @@
 (** Desugaring of syntax into the core language. *)
 
 open CoreUtils
-
 module Utils = OldUtils
 module T = Type
 module Sugared = SugaredSyntax
@@ -107,8 +106,7 @@ let desugar_pattern state ?(initial_forbidden= []) p =
   let forbidden = ref initial_forbidden in
   let new_var x =
     if List.mem x !forbidden then
-      Error.syntax ~loc:p.at
-        "Variable %s occurs more than once in a pattern" x
+      Error.syntax ~loc:p.at "Variable %s occurs more than once in a pattern" x
     else
       let var = fresh_var (Some x) in
       vars := Assoc.update x var !vars ;
@@ -212,15 +210,14 @@ let rec desugar_expression state {it= t; at= loc} =
 
 and desugar_computation state {it= t; at= loc} =
   let if_then_else e c1 c2 =
-    let true_p = add_loc (Untyped.PConst Const.of_true) (c1.at) in
-    let false_p = add_loc (Untyped.PConst Const.of_false) (c2.at) in
+    let true_p = add_loc (Untyped.PConst Const.of_true) c1.at in
+    let false_p = add_loc (Untyped.PConst Const.of_false) c2.at in
     Untyped.Match (e, [(true_p, c1); (false_p, c2)])
   in
   let w, c =
     match t with
     | Sugared.Apply
-        ( { it= Sugared.Apply ({it= Sugared.Var "&&"; at= loc1}, t1)
-          ; at= loc2 }
+        ( {it= Sugared.Apply ({it= Sugared.Var "&&"; at= loc1}, t1); at= loc2}
         , t2 ) ->
         let w1, e1 = desugar_expression state t1 in
         let untyped_false loc = add_loc (Untyped.Const Const.of_false) loc in
@@ -228,8 +225,7 @@ and desugar_computation state {it= t; at= loc} =
         let c2 = add_loc (Untyped.Value (untyped_false loc2)) loc2 in
         (w1, if_then_else e1 c1 c2)
     | Sugared.Apply
-        ( { it= Sugared.Apply ({it= Sugared.Var "||"; at= loc1}, t1)
-          ; at= loc2 }
+        ( {it= Sugared.Apply ({it= Sugared.Var "||"; at= loc1}, t1); at= loc2}
         , t2 ) ->
         let w1, e1 = desugar_expression state t1 in
         let untyped_true loc = add_loc (Untyped.Const Const.of_true) loc in

--- a/src/parsing/parser.mly
+++ b/src/parsing/parser.mly
@@ -1,9 +1,6 @@
 %{
   open SugaredSyntax
-
-  let add_loc t loc = {CoreUtils.it= t; CoreUtils.at= loc}
-  let loc_of loc_t = loc_t.CoreUtils.at
-  let term_of loc_t = loc_t.CoreUtils.it
+  open CoreUtils
 
   type handler_clause =
     | EffectClause of OldUtils.effect * abstraction2
@@ -14,7 +11,7 @@
     let (eff_cs, val_cs, fin_cs) =
       List.fold_left
         (fun (eff_cs, val_cs, fin_cs) clause ->
-          match term_of clause with
+          match clause.it with
           | EffectClause (eff, a2) ->  ((eff, a2) :: eff_cs, val_cs, fin_cs)
           | ReturnClause a -> (eff_cs, a :: val_cs, fin_cs)
           | FinallyClause a -> (eff_cs, val_cs, a :: fin_cs))
@@ -123,7 +120,7 @@ plain_topdef:
     { Commands.DefEffect (eff, (t1, t2))}
   | EFFECT eff = effect COLON t = prod_ty
     { let unit_loc = Location.make $startpos(t) $endpos(t) in
-      Commands.DefEffect (eff, (add_loc (TyTuple []) unit_loc, t))}
+      Commands.DefEffect (eff, ({it= TyTuple []; at= unit_loc}, t))}
 
 (* Toplevel directive If you change these, make sure to update lname as well,
    or a directive might become a reserved word. *)
@@ -149,11 +146,11 @@ plain_term:
   | FUNCTION cases = cases(function_case) (* END *)
     { Function cases }
   | HANDLER h = handler (* END *)
-    { term_of h }
+    { h.it }
   | HANDLE t = term WITH h = handler (* END *)
     { Handle (h, t) }
   | FUN t = lambdas1(ARROW)
-    { term_of t }
+    { t.it }
   | LET defs = separated_nonempty_list(AND, let_def) IN t = term
     { Let (defs, t) }
   | LET REC defs = separated_nonempty_list(AND, let_rec_def) IN t = term
@@ -161,7 +158,7 @@ plain_term:
   | WITH h = term HANDLE t = term
     { Handle (h, t) }
   | t1 = term SEMI t2 = term
-    { Let ([add_loc PNonbinding (loc_of t1), t1], t2) }
+    { Let ([{it= PNonbinding; at= t1.at}, t1], t2) }
   | IF t_cond = comma_term THEN t_true = term ELSE t_false = term
     { Conditional (t_cond, t_true, t_false) }
   | t = plain_comma_term
@@ -179,12 +176,12 @@ plain_binop_term:
   | t1 = binop_term op = binop t2 = binop_term
     {
       let op_loc = Location.make $startpos(op) $endpos(op) in
-      let partial = Apply (add_loc (Var op) op_loc, t1) in
+      let partial = Apply ({it= Var op; at= op_loc}, t1) in
       let partial_pos = Location.make $startpos(t1) $endpos(op) in
-      Apply (add_loc partial partial_pos, t2)
+      Apply ({it= partial; at= partial_pos}, t2)
     }
   | t1 = binop_term CONS t2 = binop_term
-    { let tuple = add_loc (Tuple [t1; t2]) (Location.make $startpos $endpos) in
+    { let tuple = {it= Tuple [t1; t2]; at= Location.make $startpos $endpos} in
       Variant (OldUtils.cons, Some tuple) }
   | t = plain_uminus_term
     { t }
@@ -193,10 +190,10 @@ uminus_term: mark_position(plain_uminus_term) { $1 }
 plain_uminus_term:
   | MINUS t = uminus_term
     { let op_loc = Location.make $startpos($1) $endpos($1) in
-      Apply (add_loc (Var "~-") op_loc, t) }
+      Apply ({it= Var "~-"; at= op_loc}, t) }
   | MINUSDOT t = uminus_term
     { let op_loc = Location.make $startpos($1) $endpos($1) in
-      Apply (add_loc (Var "~-.") op_loc, t) }
+      Apply ({it= Var "~-."; at= op_loc}, t) }
   | t = plain_app_term
     { t }
 
@@ -205,12 +202,12 @@ plain_app_term:
     { Check t }
   | t = prefix_term ts = prefix_term+
     {
-      match term_of t, ts with
+      match t.it, ts with
       | Variant (lbl, None), [t] -> Variant (lbl, Some t)
-      | Variant (lbl, _), _ -> Error.syntax ~loc:(loc_of t) "Label %s applied to too many argument" lbl
+      | Variant (lbl, _), _ -> Error.syntax ~loc:(t.at) "Label %s applied to too many argument" lbl
       | _, _ ->
-        let apply t1 t2 = add_loc (Apply(t1, t2)) (Location.union [loc_of t1; loc_of t2]) in
-        term_of (List.fold_left apply t ts)
+        let apply t1 t2 = {it= Apply(t1, t2); at= Location.union [t1.at; t2.at]} in
+        (List.fold_left apply t ts).it
     }
   | t = plain_prefix_term
     { t }
@@ -220,7 +217,7 @@ plain_prefix_term:
   | op = prefixop t = simple_term
     {
       let op_loc = Location.make $startpos(op) $endpos(op) in
-      Apply (add_loc (Var op) op_loc, t)
+      Apply ({it= Var op; at= op_loc}, t)
     }
   | t = plain_simple_term
     { t }
@@ -237,16 +234,16 @@ plain_simple_term:
     { Effect (eff, t)}
   | PERFORM eff = effect
     { let unit_loc = Location.make $startpos(eff) $endpos(eff) in
-      Effect (eff, add_loc (Tuple []) unit_loc)}
+      Effect (eff, {it= Tuple []; at= unit_loc})}
   | LBRACK ts = separated_list(SEMI, comma_term) RBRACK
     {
-      let nil = add_loc (Variant (OldUtils.nil, None)) (Location.make $endpos $endpos) in
+      let nil = {it= Variant (OldUtils.nil, None); at= Location.make $endpos $endpos} in
       let cons t ts =
-        let loc = Location.union [loc_of t; loc_of ts] in
-        let tuple = add_loc (Tuple [t; ts]) loc in
-        add_loc (Variant (OldUtils.cons, Some tuple)) loc
+        let loc = Location.union [t.at; ts.at] in
+        let tuple = {it= Tuple [t; ts];at= loc} in
+        {it= Variant (OldUtils.cons, Some tuple); at= loc}
       in
-      term_of (List.fold_right cons ts nil)
+      (List.fold_right cons ts nil).it
     }
   | LBRACE flds = separated_nonempty_list(SEMI, separated_pair(field, EQUAL, comma_term)) RBRACE
     { Record (Assoc.of_list flds) }
@@ -280,23 +277,23 @@ match_case:
     { Eff_match (eff, (p, k, t)) }
   | EFFECT eff = effect k = simple_pattern ARROW t = term
     { let unit_loc = Location.make $startpos(eff) $endpos(eff) in
-      Eff_match (eff, (add_loc (PTuple []) unit_loc, k, t)) }
+      Eff_match (eff, ({it= PTuple []; at= unit_loc}, k, t)) }
 
 lambdas0(SEP):
   | SEP t = term
     { t }
   | p = simple_pattern t = lambdas0(SEP)
-    { add_loc (Lambda (p, t)) (Location.make $startpos $endpos) }
+    { {it= Lambda (p, t); at= Location.make $startpos $endpos} }
 
 lambdas1(SEP):
   | p = simple_pattern t = lambdas0(SEP)
-    { add_loc (Lambda (p, t)) (Location.make $startpos $endpos) }
+    { {it= Lambda (p, t); at= Location.make $startpos $endpos} }
 
 let_def:
   | p = pattern EQUAL t = term
     { (p, t) }
   | x = mark_position(ident) t = lambdas1(EQUAL)
-    { (add_loc (PVar (term_of x)) (loc_of x), t) }
+    { ({it= PVar x.it; at= x.at}, t) }
 
 let_rec_def:
   | f = ident t = lambdas0(EQUAL)
@@ -308,7 +305,7 @@ plain_handler_clause:
     { EffectClause (eff, (p, k, t)) }
   | EFFECT eff = effect  k = simple_pattern ARROW t = term
     { let unit_loc = Location.make $startpos(eff) $endpos(eff) in
-      EffectClause (eff, (add_loc (PTuple []) unit_loc, k, t)) }
+      EffectClause (eff, ({it= PTuple []; at= unit_loc}, k, t)) }
   | c = function_case
     { ReturnClause c }
   | FINALLY c = function_case
@@ -317,21 +314,21 @@ plain_handler_clause:
 pattern: mark_position(plain_pattern) { $1 }
 plain_pattern:
   | p = comma_pattern
-    { term_of p }
+    { p.it }
   | p = pattern AS x = lname
     { PAs (p, x) }
 
 comma_pattern: mark_position(plain_comma_pattern) { $1 }
 plain_comma_pattern:
   | ps = separated_nonempty_list(COMMA, cons_pattern)
-    { match ps with [p] -> term_of p | ps -> PTuple ps }
+    { match ps with [p] -> p.it | ps -> PTuple ps }
 
 cons_pattern: mark_position(plain_cons_pattern) { $1 }
 plain_cons_pattern:
   | p = variant_pattern
-    { term_of p }
+    { p.it }
   | p1 = variant_pattern CONS p2 = cons_pattern
-    { let ptuple = add_loc (PTuple [p1; p2]) (Location.make $startpos $endpos) in
+    { let ptuple = {it= PTuple [p1; p2]; at= Location.make $startpos $endpos} in
       PVariant (OldUtils.cons, Some ptuple) }
 
 variant_pattern: mark_position(plain_variant_pattern) { $1 }
@@ -339,7 +336,7 @@ plain_variant_pattern:
   | lbl = UNAME p = simple_pattern
     { PVariant (lbl, Some p) }
   | p = simple_pattern
-    { term_of p }
+    { p.it }
 
 simple_pattern: mark_position(plain_simple_pattern) { $1 }
 plain_simple_pattern:
@@ -355,18 +352,18 @@ plain_simple_pattern:
     { PRecord (Assoc.of_list flds) }
   | LBRACK ts = separated_list(SEMI, pattern) RBRACK
     {
-      let nil = add_loc (PVariant (OldUtils.nil, None)) (Location.make $endpos $endpos) in
+      let nil = {it= PVariant (OldUtils.nil, None);at= Location.make $endpos $endpos} in
       let cons t ts =
-        let loc = Location.union [loc_of t; loc_of ts] in
-        let tuple = add_loc (PTuple [t; ts]) loc in
-        add_loc (PVariant (OldUtils.cons, Some tuple)) loc
+        let loc = Location.union [t.at; ts.at] in
+        let tuple = {it= PTuple [t; ts]; at= loc} in
+        {it= PVariant (OldUtils.cons, Some tuple); at= loc}
       in
-      term_of (List.fold_right cons ts nil)
+      (List.fold_right cons ts nil).it
     }
   | LPAREN RPAREN
     { PTuple [] }
   | LPAREN p = pattern RPAREN
-    { term_of p }
+    { p.it }
 
 handler: mark_position(plain_handler) { $1 }
 plain_handler:
@@ -461,7 +458,7 @@ cases(case):
 
 mark_position(X):
   x = X
-  { add_loc x (Location.make $startpos $endpos)}
+  { {it= x; at= Location.make $startpos $endpos}}
 
 params:
   |
@@ -498,7 +495,7 @@ plain_prod_ty:
     {
       match ts with
       | [] -> assert false
-      | [t] -> term_of t
+      | [t] -> t.it
       | _ -> TyTuple ts
      }
 
@@ -517,7 +514,7 @@ plain_simple_ty:
   | t = PARAM
     { TyParam t }
   | LPAREN t = ty RPAREN
-    { term_of t }
+    { t.it }
 
 sum_case:
   | lbl = UNAME

--- a/src/syntax/commands.ml
+++ b/src/syntax/commands.ml
@@ -1,7 +1,9 @@
+open CoreUtils
+
 module Sugared = SugaredSyntax
 
 (* Toplevel commands (the first four do not need to be separated by [;;]) *)
-type t = plain_command CoreUtils.located
+type t = plain_command located
 
 and plain_command =
   | Tydef of (OldUtils.tyname, OldUtils.typaram list * Sugared.tydef) Assoc.t

--- a/src/syntax/sugaredSyntax.ml
+++ b/src/syntax/sugaredSyntax.ml
@@ -1,11 +1,12 @@
 (** Abstract syntax of eff terms, types, and toplevel commands. *)
+open CoreUtils
 
 (** Terms *)
 type variable = string
 
 type effect = OldUtils.effect
 
-type pattern = plain_pattern CoreUtils.located
+type pattern = plain_pattern located
 
 and plain_pattern =
   | PVar of variable
@@ -19,7 +20,7 @@ and plain_pattern =
 (* Changing the datatype [plain_pattern] will break [specialize_vector] in [exhaust.ml] because
    of wildcard matches there. *)
 
-type term = plain_term CoreUtils.located
+type term = plain_term located
 
 and plain_term =
   | Var of variable  (** variables *)
@@ -62,7 +63,7 @@ type dirt = DirtParam of OldUtils.dirtparam
 
 type region = RegionParam of OldUtils.regionparam
 
-type ty = plain_ty CoreUtils.located
+type ty = plain_ty located
 
 and plain_ty =
   | TyApply of OldUtils.tyname * ty list

--- a/src/syntax/untypedSyntax.ml
+++ b/src/syntax/untypedSyntax.ml
@@ -1,4 +1,5 @@
 (** Syntax of the core language. *)
+open CoreUtils
 
 module Variable = Symbol.Make (Symbol.String)
 module EffectMap = Map.Make (String)
@@ -7,16 +8,7 @@ type variable = Variable.t
 
 type effect = OldUtils.effect
 
-let add_loc t loc = {CoreUtils.it= t; CoreUtils.at= loc}
-
-let loc_of loc_t = loc_t.CoreUtils.at
-
-let term_of loc_t = loc_t.CoreUtils.it
-
-(* Changing the datatype [plain_pattern] will break [specialize_vector] in [exhaust.ml] because
-   of wildcard matches there. *)
-
-type pattern = plain_pattern CoreUtils.located
+type pattern = plain_pattern located
 
 and plain_pattern =
   | PVar of variable
@@ -28,7 +20,7 @@ and plain_pattern =
   | PNonbinding
 
 (** Pure expressions *)
-type expression = plain_expression CoreUtils.located
+type expression = plain_expression located
 
 and plain_expression =
   | Var of variable
@@ -41,7 +33,7 @@ and plain_expression =
   | Handler of handler
 
 (** Impure computations *)
-and computation = plain_computation CoreUtils.located
+and computation = plain_computation located
 
 and plain_computation =
   | Value of expression
@@ -66,7 +58,7 @@ and abstraction2 = (pattern * pattern * computation)
 
 let rec print_pattern ?max_level p ppf =
   let print ?at_level = Print.print ?max_level ?at_level ppf in
-  match term_of p with
+  match p.it with
   | PVar x -> print "%t" (Variable.print x)
   | PAs (p, x) -> print "%t as %t" (print_pattern p) (Variable.print x)
   | PConst c -> Const.print c ppf
@@ -74,7 +66,7 @@ let rec print_pattern ?max_level p ppf =
   | PRecord lst -> Print.record print_pattern lst ppf
   | PVariant (lbl, None) when lbl = OldUtils.nil -> print "[]"
   | PVariant (lbl, None) -> print "%s" lbl
-  | PVariant (lbl, Some {CoreUtils.it= PTuple [v1; v2]})
+  | PVariant (lbl, Some {it= PTuple [v1; v2]})
     when lbl = OldUtils.cons ->
       print "[@[<hov>@[%t@]%t@]]" (print_pattern v1) (pattern_list v2)
   | PVariant (lbl, Some p) ->
@@ -83,8 +75,8 @@ let rec print_pattern ?max_level p ppf =
 
 and pattern_list ?(max_length= 299) p ppf =
   if max_length > 1 then
-    match term_of p with
-    | PVariant (lbl, Some {CoreUtils.it= PTuple [v1; v2]})
+    match p.it with
+    | PVariant (lbl, Some {it= PTuple [v1; v2]})
       when lbl = OldUtils.cons ->
         Format.fprintf ppf ",@ %t%t" (print_pattern v1)
           (pattern_list ~max_length:(max_length - 1) v2)
@@ -94,7 +86,7 @@ and pattern_list ?(max_length= 299) p ppf =
 
 let rec print_computation ?max_level c ppf =
   let print ?at_level = Print.print ?max_level ?at_level ppf in
-  match term_of c with
+  match c.it with
   | Apply (e1, e2) ->
       print ~at_level:1 "%t %t" (print_expression e1)
         (print_expression ~max_level:0 e2)
@@ -113,7 +105,7 @@ let rec print_computation ?max_level c ppf =
 
 and print_expression ?max_level e ppf =
   let print ?at_level = Print.print ?max_level ?at_level ppf in
-  match term_of e with
+  match e.it with
   | Var x -> print "%t" (Variable.print x)
   | Const c -> print "%t" (Const.print c)
   | Tuple lst -> Print.tuple print_expression lst ppf

--- a/src/syntax/untypedSyntax.ml
+++ b/src/syntax/untypedSyntax.ml
@@ -1,6 +1,5 @@
 (** Syntax of the core language. *)
 open CoreUtils
-
 module Variable = Symbol.Make (Symbol.String)
 module EffectMap = Map.Make (String)
 
@@ -66,8 +65,7 @@ let rec print_pattern ?max_level p ppf =
   | PRecord lst -> Print.record print_pattern lst ppf
   | PVariant (lbl, None) when lbl = OldUtils.nil -> print "[]"
   | PVariant (lbl, None) -> print "%s" lbl
-  | PVariant (lbl, Some {it= PTuple [v1; v2]})
-    when lbl = OldUtils.cons ->
+  | PVariant (lbl, Some {it= PTuple [v1; v2]}) when lbl = OldUtils.cons ->
       print "[@[<hov>@[%t@]%t@]]" (print_pattern v1) (pattern_list v2)
   | PVariant (lbl, Some p) ->
       print ~at_level:1 "%s @[<hov>%t@]" lbl (print_pattern p)
@@ -76,8 +74,7 @@ let rec print_pattern ?max_level p ppf =
 and pattern_list ?(max_length= 299) p ppf =
   if max_length > 1 then
     match p.it with
-    | PVariant (lbl, Some {it= PTuple [v1; v2]})
-      when lbl = OldUtils.cons ->
+    | PVariant (lbl, Some {it= PTuple [v1; v2]}) when lbl = OldUtils.cons ->
         Format.fprintf ppf ",@ %t%t" (print_pattern v1)
           (pattern_list ~max_length:(max_length - 1) v2)
     | PVariant (lbl, None) when lbl = OldUtils.nil -> ()

--- a/src/type-system/simpleInfer.ml
+++ b/src/type-system/simpleInfer.ml
@@ -1,5 +1,4 @@
 open CoreUtils
-
 module C = OldUtils
 module T = Type
 module Untyped = UntypedSyntax
@@ -37,7 +36,6 @@ let nonexpansive = function
    |Untyped.LetRec _ | Untyped.Check _ ->
       false
 
-
 let empty_constraint = []
 
 let add_ty_constraint cstr loc t1 t2 = cstr := (t1, t2, loc) :: !cstr
@@ -47,7 +45,6 @@ let ty_of_const = function
   | Const.String _ -> Type.string_ty
   | Const.Boolean _ -> Type.bool_ty
   | Const.Float _ -> Type.float_ty
-
 
 (* [infer_pattern cstr pp] infers the type of pattern [pp]. It returns the list of
    pattern variables with their types, which are all guaranteed to be [Type.Meta]'s, together
@@ -100,7 +97,6 @@ let infer_pattern cstr pp =
   let t = infer pp in
   (!vars, t)
 
-
 let extend_with_pattern ?(forbidden_vars= []) ctx cstr p =
   let vars, t = infer_pattern cstr p in
   match OldUtils.find (fun (x, _) -> List.mem_assoc x vars) forbidden_vars with
@@ -112,12 +108,10 @@ let extend_with_pattern ?(forbidden_vars= []) ctx cstr p =
       , t
       , List.fold_right (fun (x, t) ctx -> Ctx.extend_ty ctx x t) vars ctx )
 
-
 let rec infer_abstraction ctx cstr (p, c) =
   let _, t1, ctx = extend_with_pattern ctx cstr p in
   let t2 = infer_comp ctx cstr c in
   (t1, t2)
-
 
 and infer_abstraction2 ctx cstr (p1, p2, c) =
   let vs, t1, ctx = extend_with_pattern ctx cstr p1 in
@@ -125,13 +119,11 @@ and infer_abstraction2 ctx cstr (p1, p2, c) =
   let t3 = infer_comp ctx cstr c in
   (t1, t2, t3)
 
-
 and infer_handler_case_abstraction ctx cstr (p, k, e) =
   let vs, t1, ctx = extend_with_pattern ctx cstr p in
   let _, tk, ctx = extend_with_pattern ~forbidden_vars:vs ctx cstr k in
   let t2 = infer_comp ctx cstr e in
   (tk, t1, t2)
-
 
 and infer_let ctx cstr loc defs =
   ( if !warn_implicit_sequencing && List.length defs >= 2 then
@@ -153,9 +145,7 @@ and infer_let ctx cstr loc defs =
             let sbst = Unify.solve !cstr in
             let ws = Assoc.map (T.subst_ty sbst) (Assoc.of_list ws) in
             let ctx = Ctx.subst_ctx ctx sbst in
-            let ws =
-              Assoc.map (Ctx.generalize ctx (nonexpansive c.it)) ws
-            in
+            let ws = Assoc.map (Ctx.generalize ctx (nonexpansive c.it)) ws in
             let ws = Assoc.to_list ws in
             let ctx' =
               List.fold_right
@@ -166,7 +156,6 @@ and infer_let ctx cstr loc defs =
       ([], ctx) defs
   in
   (vars, Ctx.subst_ctx ctx (Unify.solve !cstr))
-
 
 and infer_let_rec ctx cstr loc defs =
   if not (OldUtils.injective fst defs) then
@@ -207,7 +196,6 @@ and infer_let_rec ctx cstr loc defs =
       vars ctx
   in
   (vars, ctx)
-
 
 (* [infer_expr ctx cstr (e,loc)] infers the type of expression [e] in context
    [ctx]. It returns the inferred type of [e]. *)
@@ -287,7 +275,6 @@ and infer_expr ctx cstr {it= e; at= loc} =
       add_ty_constraint cstr loc fint1 t_yield ;
       T.Handler {T.value= t_value; T.finally= t_finally}
 
-
 (* [infer_comp ctx cstr (c,loc)] infers the type of computation [c] in context [ctx].
    It returns the list of newly introduced meta-variables and the inferred type. *)
 and infer_comp ctx cstr cp =
@@ -337,7 +324,6 @@ and infer_comp ctx cstr cp =
     let ty = infer ctx cp in
     ty
 
-
 let infer_top_comp ctx c =
   let cstr = ref [] in
   let ty = infer_comp ctx cstr c in
@@ -347,14 +333,12 @@ let infer_top_comp ctx c =
   let ty = Type.subst_ty sbst ty in
   (ctx, Ctx.generalize ctx (nonexpansive c.it) ty)
 
-
 let infer_top_let ~loc ctx defs =
   let vars, ctx = infer_let ctx (ref empty_constraint) Location.unknown defs in
   List.iter
     (fun (p, c) -> Exhaust.is_irrefutable p ; Exhaust.check_comp c)
     defs ;
   (vars, ctx)
-
 
 let infer_top_let_rec ~loc ctx defs =
   let vars, ctx =


### PR DESCRIPTION
`CoreUtils` are now opened which greatly improves readability.