### PR TITLE
Change clone URLs to https

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ This is the easiest way to install Eff. Follow these steps:
 
 3. Run
 
-        opam pin add -k git eff git@github.com:matijapretnar/eff.git
+        opam pin add -k git eff https://github.com/matijapretnar/eff.git
 
    OPAM will download and build the necessary dependencies first, then download
    and build Eff itself.
@@ -74,7 +74,7 @@ This is the easiest way to install Eff. Follow these steps:
 
 To compile Eff manually, first clone the GitHub repository
 
-    git clone git@github.com:matijapretnar/eff.git
+    git clone https://github.com/matijapretnar/eff.git
     cd eff
 
 and run


### PR DESCRIPTION
Prevents this error while pulling the repo:


```sh
opam pin add -k git eff git@github.com:matijapretnar/eff.git

Package eff does not exist, create as a NEW package? [Y/n] Y
Processing: [eff.~dev: git]The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
[ERROR] Could not synchronize /Users/james.kraus/.opam/system/.opam-switch/sources/eff from "git+ssh://git@github.com/matijapretnar/eff.git":
        "/usr/bin/git fetch -q" exited with code 128
[ERROR] Error getting source from git+ssh://git@github.com/matijapretnar/eff.git:
          - git+ssh://git@github.com/matijapretnar/eff.git
```